### PR TITLE
[#5] Fix checks for presence of Permit.Ecto

### DIFF
--- a/lib/live_view.ex
+++ b/lib/live_view.ex
@@ -44,7 +44,7 @@ defmodule Permit.Phoenix.LiveView do
   import Phoenix.LiveView
 
   @callback resource_module() :: module()
-  with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
+  if :ok == Application.ensure_loaded(:permit_ecto) do
     @callback base_query(Types.resolution_context()) :: Ecto.Query.t()
     @callback finalize_query(Ecto.Query.t(), Types.resolution_context()) :: Ecto.Query.t()
   end
@@ -62,10 +62,10 @@ defmodule Permit.Phoenix.LiveView do
   @callback id_struct_field_name(Types.action_group(), PhoenixTypes.socket()) :: atom()
 
   @optional_callbacks [
-                        if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+                        if(:ok == Application.ensure_loaded(:permit_ecto),
                           do: {:base_query, 1}
                         ),
-                        if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+                        if(:ok == Application.ensure_loaded(:permit_ecto),
                           do: {:finalize_query, 2}
                         ),
                         handle_unauthorized: 2,
@@ -83,7 +83,7 @@ defmodule Permit.Phoenix.LiveView do
     quote generated: true do
       import unquote(__MODULE__)
 
-      with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
+      if :ok == Application.ensure_loaded(:permit_ecto) do
         require Ecto.Query
       end
 
@@ -114,7 +114,7 @@ defmodule Permit.Phoenix.LiveView do
       @impl true
       def except, do: unquote(opts[:except]) || []
 
-      if {:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto) do
+      if :ok == Application.ensure_loaded(:permit_ecto) do
         @impl true
         def base_query(%{
               action: action,
@@ -157,10 +157,10 @@ defmodule Permit.Phoenix.LiveView do
 
       defoverridable(
         [
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:base_query, 1}
           ),
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:finalize_query, 2}
           ),
           handle_unauthorized: 2,
@@ -223,7 +223,7 @@ defmodule Permit.Phoenix.LiveView do
     end
   end
 
-  if {:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto) do
+  if :ok == Application.ensure_loaded(:permit_ecto) do
     @doc false
     def base_query(
           %{

--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -404,11 +404,10 @@ defmodule Permit.Phoenix.Controller do
 
       case params do
         %{^param => id} ->
-          resource_module
-          |> Permit.Ecto.filter_by_field(field, id)
+          apply(Permit.Ecto, :filter_by_field, [resource_module, field, id])
 
         _ ->
-          Permit.Ecto.from(resource_module)
+          apply(Permit.Ecto, :from, [resource_module])
       end
     end
 

--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -72,7 +72,7 @@ defmodule Permit.Phoenix.Controller do
   """
   @callback resource_module() :: Types.resource_module()
 
-  with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
+  if :ok == Application.ensure_loaded(:permit_ecto) do
     @doc ~S"""
     Creates the basis for an Ecto query constructed by `Permit.Ecto` based on controller action, resource module, subject (typically `:current_user`) and controller params.
 
@@ -209,10 +209,10 @@ defmodule Permit.Phoenix.Controller do
   @callback id_struct_field_name(Types.action_group(), PhoenixTypes.conn()) :: atom()
 
   @optional_callbacks [
-                        if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+                        if(:ok == Application.ensure_loaded(:permit_ecto),
                           do: {:base_query, 1}
                         ),
-                        if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+                        if(:ok == Application.ensure_loaded(:permit_ecto),
                           do: {:finalize_query, 2}
                         ),
                         handle_unauthorized: 2,
@@ -228,10 +228,6 @@ defmodule Permit.Phoenix.Controller do
   defmacro __using__(opts) do
     quote generated: true do
       require Logger
-
-      # with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
-      #   require Ecto.Query
-      # end
 
       @behaviour unquote(__MODULE__)
 
@@ -264,7 +260,7 @@ defmodule Permit.Phoenix.Controller do
         unquote(__MODULE__).except(unquote(opts))
       end
 
-      with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
+      if :ok == Application.ensure_loaded(:permit_ecto) do
         @impl true
         def base_query(%{
               action: action,
@@ -312,10 +308,10 @@ defmodule Permit.Phoenix.Controller do
 
       defoverridable(
         [
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:base_query, 1}
           ),
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:finalize_query, 2}
           ),
           handle_unauthorized: 2,
@@ -334,10 +330,10 @@ defmodule Permit.Phoenix.Controller do
       plug(
         Permit.Phoenix.Plug,
         [
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:base_query, &__MODULE__.base_query/1}
           ),
-          if({:module, Permit.Ecto} == Code.ensure_compiled(Permit.Ecto),
+          if(:ok == Application.ensure_loaded(:permit_ecto),
             do: {:finalize_query, &__MODULE__.finalize_query/2}
           ),
           authorization_module: &__MODULE__.authorization_module/0,
@@ -392,7 +388,7 @@ defmodule Permit.Phoenix.Controller do
     end
   end
 
-  with {:module, Permit.Ecto} <- Code.ensure_compiled(Permit.Ecto) do
+  if :ok == Application.ensure_loaded(:permit_ecto) do
     @doc false
     def base_query(
           %{

--- a/lib/permit_phoenix/types.ex
+++ b/lib/permit_phoenix/types.ex
@@ -37,7 +37,7 @@ defmodule Permit.Phoenix.Types do
   """
   @type handle_unauthorized :: (Types.action_group(), conn() -> conn())
 
-  if {:module, Permit.Ecto.Types} == Code.ensure_compiled(EctoTypes) do
+  if :ok == Application.ensure_loaded(:permit_ecto) do
     @typedoc """
     - `:authorization_module` -- (Required) The app's authorization module that uses `use Permit`.
     - `preload_actions` -- (Optional) The list of actions that resources will be preloaded and authorized in, in addition to :show, :delete, :edit and :update.


### PR DESCRIPTION
Resolves #5 by using a different way to check for Permit.Ecto in compile time.