### PR TITLE
Conditionally add base_query/1 and finalize_query/2 callbacks via macro

### DIFF
--- a/lib/permit_phoenix/macros.ex
+++ b/lib/permit_phoenix/macros.ex
@@ -1,0 +1,12 @@
+defmodule PermitPhoenix.Macros do
+  @moduledoc false
+
+  defmacro permit_ecto_callbacks do
+    if :ok == Application.ensure_loaded(:permit_ecto) do
+      quote do
+        @callback base_query(Types.resolution_context()) :: Ecto.Query.t()
+        @callback finalize_query(Ecto.Query.t(), Types.resolution_context()) :: Ecto.Query.t()
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolve #20. Callbacks `base_query/1` and `finalize_query/2` are not inserted in compile-time. This wraps them in a macro to insert them when `permit_ecto` is loaded conditionally. It has a similar approach used by the decimal library as mentioned here https://elixirforum.com/t/conditional-compilation-of-callback-and-impl/23149.