### PR TITLE
Bump version to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-06-03
+
 ### Added
 - Support for automatic inference of action names from controller routes
 - Support for automatic inference of action names from LiveView routes

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Permit.Phoenix.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @source_url "https://github.com/curiosum-dev/permit_phoenix"
 
   def project do


### PR DESCRIPTION
This PR bumps the version from v0.2.0 to v0.3.0 and updates the changelog accordingly.

## Changes Made:
- Updated `@version` in `mix.exs` from `"0.2.0"` to `"0.3.0"`
- Updated `CHANGELOG.md` to move unreleased features to version 0.3.0 with today's date
- Added proper changelog entry for the new version

## Features included in v0.3.0:
- Support for automatic inference of action names from controller routes
- Support for automatic inference of action names from LiveView routes
- Support for Phoenix LiveView 1.x
- Various bug fixes and improvements

Fixes #30