### PR TITLE
feat: :sparkles: add Phoenix Scopes handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Breaking] Support for Phoenix Scopes integration in LiveViews & controllers (#33)
+
+  LiveViews can now integrate with [Phoenix Scopes](https://hexdocs.pm/phoenix/scopes.html) (available in Phoenix 1.8+) for authorization. When enabled via the `use_scope?/0` callback, the LiveView will use `:current_scope` instead of `:current_user` for the subject assign. This is particularly useful for multi-tenant applications or when additional context beyond the user is needed. Example:
+
+  To bootstrap it in the current version of Phoenix (>= 1.8) and LiveView, this is really all you need to do now:
+  ```elixir
+  defmodule MyAppWeb.ArticleLive.Index do
+    # Put it in the controller, or the `MyAppWeb` module's `live_view` function
+    use Permit.Phoenix.LiveView,
+      authorization_module: MyApp.Authorization,
+      resource_module: MyApp.Article
+
+    # If you're using Phoenix >=1.8's `mix phx.gen.auth` and only need to authorize against,
+    # the current user (`@current_scope.user`), that's all!
+  end
+  ```
+
+  Options can be set using `use` options or callback implementations. You can switch to authorizing against `@current_user`, using a different scope key (or the entire scope) as the subject, or fetch the subject from the session.
+  See the README for a full configuration guidance.
+  ```
+
+  In Controllers, likewise, you can use the :use_scope? option or callback to enable or disable scope-based subject assignment.
+
+### Changed
+
+- [Breaking] Permit.Phoenix.LiveView no longer needs to have the `fetch_subject/2` callback implemented, and its result is no longer assigned to the `:current_user` assign - so that Permit no longer interferes with your assigns. This was a leftover from before `mix phx.gen.auth` became the de facto standard.
+
 ## [0.3.1]
 
 ### Fixed
+
 - Fix method of checking for Permit.Ecto existence (#34). Now it should be working correctly both when using hex and path dependencies.
 - Add missing `defoverridable event_mapping: 0` to `Permit.Phoenix.LiveView` to allow overriding the `event_mapping` function in child modules.
 
 ## [0.3.0]
 
 ### Added
+
 - Support for Phoenix LiveView 1.x (#24)
 
   Dependency specs have been updated to allow LiveView 1.x usage. GitHub Actions matrix has been updated to include Elixir >= 1.14, OTP >= 26, Phoenix >= 1.6 and LiveView >= 0.20 (going forward, < 1.x will be dropped).
+
 - Support for automatic inference of action names from controller and LiveView routes (#28).
 
   Thanks to this, actions corresponding to controller actions and `:live_action` no longer have to be defined explicitly in the actions module. Example:
+
   ```elixir
   defmodule MyApp.Actions do
     # Merge the actions from the router into the default grouping schema.
@@ -32,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to use streams instead of assigns (d6e2d2d).
 
   The `use_stream?/1` callback (and `:use_stream?` option key) was added to `Permit.Phoenix.LiveView`, defaulting to `false`. When set to `true`, it directs Permit.Phoenix to insert the loaded-and-authorized resources as the `:loaded_resources` stream, as opposed to an assign key, if dealing with a plural (e.g. `:index`) action. Example:
+
   ```elixir
   defmodule MyApp.SomethingLive do
     use Permit.Phoenix.LiveView,
@@ -55,12 +89,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
 ### Fixed
+
 - Missing alias to Types in AuthorizeHook
 - `Permit.Ecto`-related callbacks not correctly defined (#23)
 - Improved detection of Permit.Ecto presence using mix lock data
 - Fix static checks, dialyzer indications, and Credo warnings
 
 ### Changed
+
 - [Breaking] Drop LiveView < 0.20 support
 - [Breaking] Skip load-and-authorize in handle_params after mount
 - Updated CI and testing configuration
@@ -69,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0]
 
 ### Added
+
 - Support for customizing responses when records are not found with `handle_not_found` callback
 - Custom RecordNotFound exception for better error handling
 - Authorization for handle_event in LiveView
@@ -76,10 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added event_mapping callback for LiveView
 
 ### Changed
+
 - Updated dependencies to latest versions of permit and permit_ecto
 - Renamed attach_params_hook to attach_hooks for better clarity
 
 ### Fixed
+
 - Allow specifying fallback_path and unauthorized_message as functions
 - Tests and fixes for fallback_path and unauthorized_message as functions
 - Fixed missing :update and :delete actions in singular and preloadable actions
@@ -89,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0]
 
 ### Added
+
 - Initial stable release
 - Phoenix Framework integration for Permit authorization library
 - LiveView integration for authorization
@@ -98,10 +138,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation and examples in README
 
 ### Changed
+
 - Upgraded dependencies to enforce usage of bugfixed versions
 - Documentation improvements and fixes to Credo indications
 - Code cleanup and test coverage improvements
 
 ### Fixed
+
 - Fixed various bugs identified during initial testing
 - Removed assigns when changing action in LiveView

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
   <p><strong>Phoenix Framework and LiveView integration for Permit - Authorization made simple for controllers and live views.
 </strong></p>
 
-  [![Contact Us](https://img.shields.io/badge/Contact%20Us-%23F36D2E?style=for-the-badge&logo=maildotru&logoColor=white&labelColor=F36D2E)](https://curiosum.com/contact)
-  [![Visit Curiosum](https://img.shields.io/badge/Visit%20Curiosum-%236819E6?style=for-the-badge&logo=elixir&logoColor=white&labelColor=6819E6)](https://curiosum.com/services/elixir-software-development)
-  [![License: MIT](https://img.shields.io/badge/License-MIT-1D0642?style=for-the-badge&logo=open-source-initiative&logoColor=white&labelColor=1D0642)]()
-</div>
+[![Contact Us](https://img.shields.io/badge/Contact%20Us-%23F36D2E?style=for-the-badge&logo=maildotru&logoColor=white&labelColor=F36D2E)](https://curiosum.com/contact)
+[![Visit Curiosum](https://img.shields.io/badge/Visit%20Curiosum-%236819E6?style=for-the-badge&logo=elixir&logoColor=white&labelColor=6819E6)](https://curiosum.com/services/elixir-software-development)
+[![License: MIT](https://img.shields.io/badge/License-MIT-1D0642?style=for-the-badge&logo=open-source-initiative&logoColor=white&labelColor=1D0642)]()
 
+</div>
 
 <br/>
 
@@ -18,6 +18,7 @@
 Permit.Phoenix provides seamless authorization integration for Phoenix Framework applications, enabling consistent permission checking across controllers and LiveViews without code duplication.
 
 Key features:
+
 - **Automatic authorization** - Plug-based controllers and LiveViews authorize actions automatically
 - **Resource preloading** - Automatically load and scope single database records and lists based on user permissions
 - **LiveView 1.0+ support** - Optional integration with streams and modern LiveView features
@@ -108,6 +109,7 @@ Basic controller and LiveView integration examples:
 ## Default action mapping
 
 By default, `Permit.Phoenix.Actions` provides the following action mapping:
+
 ```elixir
 %{
   new: [:create],
@@ -116,6 +118,7 @@ By default, `Permit.Phoenix.Actions` provides the following action mapping:
   edit: [:update]
 }
 ```
+
 This means that accessing the `:new` action will require the `:create` permission, accessing the `:index` or `:show` action will require the `:read` permission, and accessing `:edit` will require the `:update` permission - this is for convenience when using default Phoenix action names.
 
 ```elixir
@@ -128,15 +131,17 @@ end
 ### Controllers
 
 All options of `Permit.Phoenix.Controller` can be provided as option keywords with `use Permit.Phoenix.Controller` or as callback implementations. For example, defining a `handle_unauthorized: fn action, conn -> ... end` option is equivalent to:
+
 ```elixir
 @impl true
 def handle_unauthorized(action, conn), do: ...
 ```
 
 In practice, it depends on use case:
-* when providing options for different actions, etc., consider using callback implementations
-* if you want to provide values as literals instead of functions, consider using option keywords
-* for global settings throughout controllers using `use MyAppWeb, :controller`, set globals as keywords, and override in specific controllers using callback implementations.
+
+- when providing options for different actions, etc., consider using callback implementations
+- if you want to provide values as literals instead of functions, consider using option keywords
+- for global settings throughout controllers using `use MyAppWeb, :controller`, set globals as keywords, and override in specific controllers using callback implementations.
 
 Whenever `resolution_context` is referred to, it is typified by `Permit.Types.resolution_context`.
 
@@ -189,6 +194,7 @@ end
 ```
 
 #### Global usage with settings in specific controllers
+
 ```elixir
 defmodule MyAppWeb do
   def controller do
@@ -304,6 +310,146 @@ defmodule MyAppWeb.Router do
 end
 ```
 
+#### Using with Phoenix Scopes
+
+Permit.Phoenix LiveView and Controller integrations supports [Phoenix Scopes](https://hexdocs.pm/phoenix/scopes.html) (available in Phoenix 1.8+), which are data structures that hold information about the current request or session (current user, organization, permissions, etc.). Scopes are particularly useful for multi-tenant applications or when you need to maintain more than just user information.
+
+##### When to use Phoenix Scopes with Permit
+
+Use Phoenix Scopes when:
+
+- You have multi-tenant applications (e.g., users belong to organizations)
+- You need to maintain additional context beyond the current user (e.g., current team, workspace)
+- You're using `mix phx.gen.auth` (which automatically generates a scope)
+- You want to follow Phoenix's recommended patterns for access control
+
+Use the traditional `:current_user` approach when:
+
+- You have a simple single-tenant application
+- Only user information is needed for authorization
+- You prefer explicit user-based permissions
+
+##### Configuration with Phoenix Scopes
+
+First, ensure your scope is defined (usually generated by `mix phx.gen.auth`):
+
+```elixir
+# lib/my_app/accounts/scope.ex
+defmodule MyApp.Accounts.Scope do
+  alias MyApp.Accounts.User
+
+  defstruct user: nil
+
+  def for_user(%User{} = user) do
+    %__MODULE__{user: user}
+  end
+
+  def for_user(nil), do: nil
+end
+```
+
+Examples below are for LiveView, but configuration for controllers is identical - using `use` option keywords or callback implementations.
+
+Then, configure your LiveView to use scopes - in the current version of Phoenix (>= 1.8) and LiveView, this is really all you need to do now:
+```elixir
+defmodule MyAppWeb.ArticleLive.Index do
+  # Put it in the controller, or the `MyAppWeb` module's `live_view` function
+  use Permit.Phoenix.LiveView,
+    authorization_module: MyApp.Authorization,
+    resource_module: MyApp.Article
+
+  # If you're using Phoenix >=1.8's `mix phx.gen.auth` and only need to authorize against,
+  # the current user (`@current_scope.user`), that's all!
+end
+```
+
+For compatibility with projects created with Phoenix <1.8, or when using a custom configuration, you can disable scope-based authorization and use the traditional approach:
+
+```elixir
+defmodule MyAppWeb do
+  def live_view do
+    quote do
+      use Permit.Phoenix.LiveView,
+        authorization_module: MyApp.Authorization,
+        resource_module: MyApp.Article,
+        scope_subject: :admin # Use the admin key as the subject by default
+        use_scope?: false, # Switch to authorizing against @current_user
+        fetch_subject: fn _socket, session -> ... end # Fetch the subject from the session
+    end
+  end
+end
+```
+Then, you can override the options in a specific LiveView using callbacks - see traditional configuration example below.
+
+##### Custom Scope-Subject Mapping
+
+You can configure that the subject should be the entire scope struct, instead of just the user key, by setting `scope_subject` to `scope` itself, or perhaps a different key in the scope, e.g. `:admin`.
+
+```elixir
+defmodule MyAppWeb.ArticleLive.Index do
+  use MyAppWeb, :live_view
+
+  # Use a different key (e.g. `@current_scope.admin`), or the entire scope as the
+  # subject
+  @impl true
+  def scope_subject(scope), do: scope
+
+  @impl true
+  def mount(_params, _session, socket) do
+    # socket.assigns.current_scope contains whatever is needed in the app's context
+    {:ok, socket}
+  end
+end
+```
+
+If you've configured `scope_subject` as `scope` itself, inside the `can/1` predicates you'll have access to the entire scope struct.
+Update your permissions to work with scopes:
+
+```elixir
+defmodule MyApp.Permissions do
+  use Permit.Ecto.Permissions, actions_module: MyApp.Actions
+
+  # The subject passed will be the scope struct
+  def can(%MyApp.Accounts.Scope{user: %{id: user_id}}) do
+    permit()
+    |> read(MyApp.Article, user_id: user_id)
+    |> create(MyApp.Article)
+  end
+
+  def can(_scope), do: permit()
+end
+```
+
+##### Configuration without Phoenix Scopes (Traditional)
+
+For applications not using Phoenix Scopes, continue using the traditional approach:
+
+```elixir
+defmodule MyAppWeb.ArticleLive.Index do
+  use MyAppWeb, :live_view
+
+  # For Phoenix projects bootstrapped below 1.8, disable scope-based authorization
+  # (will take current user from the :current_user assign)
+  @impl true
+  def use_scope?, do: false
+
+  # Optional - if you need to fetch the subject differently than by default (from
+  # the :current_scope assign or the current_user assign)
+  @impl true
+  def fetch_subject(_socket, session) do
+    # Fetch and return the current user directly
+    user_token = session["user_token"]
+    user_token && MyApp.Accounts.get_user_by_session_token(user_token)
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    # The user is available as socket.assigns.current_user
+    {:ok, socket}
+  end
+end
+```
+
 #### LiveView configuration
 
 Permit.Phoenix.LiveView performs authorization at three key points:
@@ -312,12 +458,9 @@ Permit.Phoenix.LiveView performs authorization at three key points:
 2. **During live navigation** - when `handle_params/3` is called and `:live_action` changes
 3. **During events** - when `handle_event/3` is called for events defined in `event_mapping/0`
 
-
 In a similar way to configuring controllers, LiveViews can be configured with option keywords or callback implementations, thus let's omit lengthy examples of both.
 
 Most options are similar to controller options, with `socket` in place of `conn`.
-
-Note that it is mandatory to implement the `fetch_subject` callback, so it is recommended to put it as shared configuration in your web app module.
 
 ```elixir
 defmodule PermitTestWeb.ArticleLive.Index do
@@ -348,11 +491,6 @@ defmodule PermitTestWeb.ArticleLive.Index do
     # Alternatively you can implement a callback to do something different,
     # for instance you can do {:cont, ...} and assign something to the socket
     # to display a message.
-  end
-
-  @impl true
-  def fetch_subject(_socket, session) do
-    # Retrieve the current user from session
   end
 end
 ```
@@ -456,12 +594,12 @@ end
 
 Permit.Phoenix is part of the modular Permit ecosystem:
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| **[permit](https://hex.pm/packages/permit)** | [![Hex.pm](https://img.shields.io/hexpm/v/permit.svg)](https://hex.pm/packages/permit) | Core authorization library |
-| **[permit_ecto](https://hex.pm/packages/permit_ecto)** | [![Hex.pm](https://img.shields.io/hexpm/v/permit_ecto.svg)](https://hex.pm/packages/permit_ecto) | Ecto integration for database queries |
-| **[permit_phoenix](https://hex.pm/packages/permit_phoenix)** | [![Hex.pm](https://img.shields.io/hexpm/v/permit_phoenix.svg)](https://hex.pm/packages/permit_phoenix) | Phoenix Controllers & LiveView integration |
-| **[permit_absinthe](https://github.com/curiosum-dev/permit_absinthe)** | [![Hex.pm](https://img.shields.io/hexpm/v/permit_absinthe.svg)](https://hex.pm/packages/permit_absinthe) | GraphQL API authorization via Absinthe |
+| Package                                                                | Version                                                                                                  | Description                                |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **[permit](https://hex.pm/packages/permit)**                           | [![Hex.pm](https://img.shields.io/hexpm/v/permit.svg)](https://hex.pm/packages/permit)                   | Core authorization library                 |
+| **[permit_ecto](https://hex.pm/packages/permit_ecto)**                 | [![Hex.pm](https://img.shields.io/hexpm/v/permit_ecto.svg)](https://hex.pm/packages/permit_ecto)         | Ecto integration for database queries      |
+| **[permit_phoenix](https://hex.pm/packages/permit_phoenix)**           | [![Hex.pm](https://img.shields.io/hexpm/v/permit_phoenix.svg)](https://hex.pm/packages/permit_phoenix)   | Phoenix Controllers & LiveView integration |
+| **[permit_absinthe](https://github.com/curiosum-dev/permit_absinthe)** | [![Hex.pm](https://img.shields.io/hexpm/v/permit_absinthe.svg)](https://hex.pm/packages/permit_absinthe) | GraphQL API authorization via Absinthe     |
 
 ## Documentation
 
@@ -487,8 +625,8 @@ Just clone the repository, install dependencies normally, develop and run tests.
 
 ## Contact
 
-* Library maintainer: [Michał Buszkiewicz](https://github.com/vincentvanbush)
-* [**Curiosum**](https://curiosum.com) - Elixir development team behind Permit
+- Library maintainer: [Michał Buszkiewicz](https://github.com/vincentvanbush)
+- [**Curiosum**](https://curiosum.com) - Elixir development team behind Permit
 
 ## License
 

--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -242,6 +242,33 @@ defmodule Permit.Phoenix.Controller do
 
   @callback unauthorized_message(Types.action_group(), PhoenixTypes.conn()) :: binary()
 
+  @doc ~S"""
+  Determines whether to use Phoenix Scopes for fetching the subject. Set to `false` in Phoenix <1.8.
+
+  If `true`, the subject will be fetched from `current_scope.user` assign. If `false`, the subject will be fetched from `current_user` assign.
+
+  Defaults to `true`.
+  """
+  @callback use_scope?() :: boolean()
+
+  @doc ~S"""
+  Maps the current Phoenix scope to the subject, if Phoenix Scopes are used (see the `use_scope?/0` callback). Defaults to `scope.user`.
+
+  Defaults to `:user`.
+
+  ## Example
+
+      @impl true
+      def scope_subject(scope) do
+        # Use the entire scope as the subject
+        scope
+
+        # Use a specific key in the scope
+        scope.user
+      end
+  """
+  @callback scope_subject(map()) :: PhoenixTypes.scope_subject()
+
   @optional_callbacks [
                         if(@permit_ecto_available?,
                           do: {:base_query, 1}
@@ -257,7 +284,9 @@ defmodule Permit.Phoenix.Controller do
                         fetch_subject: 1,
                         loader: 1,
                         handle_not_found: 1,
-                        unauthorized_message: 2
+                        unauthorized_message: 2,
+                        use_scope?: 0,
+                        scope_subject: 1
                       ]
                       |> Enum.filter(& &1)
 
@@ -357,6 +386,16 @@ defmodule Permit.Phoenix.Controller do
       @impl true
       def singular_actions do
         unquote(opts)[:authorization_module].permissions_module().actions_module().singular_actions()
+      end
+
+      @impl true
+      def use_scope? do
+        unquote(__MODULE__).use_scope?(unquote(opts))
+      end
+
+      @impl true
+      def scope_subject(scope) do
+        unquote(__MODULE__).scope_subject(scope, unquote(opts))
       end
 
       defoverridable(
@@ -535,13 +574,31 @@ defmodule Permit.Phoenix.Controller do
   end
 
   @doc false
+  def use_scope?(opts) do
+    case opts[:use_scope?] do
+      fun when is_function(fun) -> fun.() || true
+      nil -> true
+      other -> other
+    end
+  end
+
+  @doc false
+  def scope_subject(scope, opts) do
+    case opts[:scope_subject] do
+      fun when is_function(fun) -> fun.(scope)
+      nil -> scope.user
+      key -> scope |> Map.fetch!(key)
+    end
+  end
+
+  @doc false
   def fetch_subject(conn, opts) do
     fetch_subject_fn = opts[:fetch_subject_fn]
 
-    if is_function(fetch_subject_fn, 1) do
-      fetch_subject_fn.(conn)
-    else
-      conn.assigns[:current_user]
+    cond do
+      is_function(fetch_subject_fn, 1) -> fetch_subject_fn.(conn)
+      use_scope?(opts) -> scope_subject(conn.assigns[:current_scope], opts)
+      true -> conn.assigns[:current_user]
     end
   end
 end

--- a/lib/permit_phoenix/live_view/authorize_hook.ex
+++ b/lib/permit_phoenix/live_view/authorize_hook.ex
@@ -23,14 +23,14 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
   Authorization is done on live view mount and in handle_params (where the URL, and
   hence assigns.live_action, may change).
 
-  A live view module using the authorization mechanism should mix in the LiveViewAuthorization
+  A live view module using the authorization mechanism should mix in the Permit.Phoenix.LiveView
   module:
 
       defmodule MyAppWeb.DocumentLive.Index
         use Permit.Phoenix.LiveView
       end
 
-  which adds the LiveViewAuthorization behavior with the following callbacks to be implemented -
+  which adds the Permit.Phoenix.LiveView behavior with the following callbacks to be implemented -
   for example:
 
       # The related schema
@@ -128,34 +128,27 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
 
   defp authenticate_and_authorize!(socket, action, session, params) do
     socket
-    |> authenticate(session)
-    |> authorize(action, params)
+    |> authorize(session, action, params)
     |> respond()
   end
 
-  @spec authenticate(PhoenixTypes.socket(), map()) :: PhoenixTypes.socket()
-  defp authenticate(socket, session) do
-    current_user = socket.view.fetch_subject(socket, session)
-    live_view_assign(socket, :current_user, current_user)
-  end
-
-  @spec authorize(PhoenixTypes.socket(), Types.action_group(), map()) ::
+  @spec authorize(PhoenixTypes.socket(), PhoenixTypes.session(), Types.action_group(), map()) ::
           PhoenixTypes.live_authorization_result()
-  defp authorize(socket, action, params) do
+  defp authorize(socket, session, action, params) do
     if action in socket.view.preload_actions() do
-      preload_and_authorize(socket, action, params)
+      preload_and_authorize(socket, session, action, params)
     else
-      just_authorize(socket, action)
+      just_authorize(socket, session, action)
     end
   end
 
-  @spec just_authorize(PhoenixTypes.socket(), Types.action_group()) ::
+  @spec just_authorize(PhoenixTypes.socket(), PhoenixTypes.session(), Types.action_group()) ::
           PhoenixTypes.live_authorization_result()
-  defp just_authorize(socket, action) do
+  defp just_authorize(socket, session, action) do
     authorization_module = socket.view.authorization_module()
     resource_module = socket.view.resource_module()
     resolver_module = authorization_module.resolver_module()
-    subject = socket.assigns.current_user
+    subject = get_subject(socket, session)
 
     case resolver_module.authorized?(
            subject,
@@ -168,9 +161,14 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
     end
   end
 
-  @spec preload_and_authorize(PhoenixTypes.socket(), Types.action_group(), map()) ::
+  @spec preload_and_authorize(
+          PhoenixTypes.socket(),
+          PhoenixTypes.session(),
+          Types.action_group(),
+          map()
+        ) ::
           PhoenixTypes.live_authorization_result()
-  defp preload_and_authorize(socket, action, params) do
+  defp preload_and_authorize(socket, session, action, params) do
     use_loader? = socket.view.use_loader?()
 
     authorization_module = socket.view.authorization_module()
@@ -180,7 +178,7 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
     base_query = &socket.view.base_query/1
     loader = &socket.view.loader/1
     finalize_query = &socket.view.finalize_query/2
-    subject = socket.assigns.current_user
+    subject = get_subject(socket, session)
     singular? = action in socket.view.singular_actions()
 
     {load_key, other_key, auth_function} =
@@ -221,6 +219,22 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
          socket
          |> live_view_assign(load_key, nil)
          |> live_view_assign(other_key, nil)}
+    end
+  end
+
+  defp get_subject(socket, session) do
+    # In Phoenix <1.8, phx.gen.auth would assign the current user to the :current_user assign.
+    # In Phoenix >=1.8, phx.gen.auth now assign it to the :user key in the scope.
+
+    cond do
+      function_exported?(socket.view, :fetch_subject, 2) ->
+        socket.view.fetch_subject(socket, session)
+
+      socket.view.use_scope?() ->
+        socket.view.scope_subject(socket.assigns[:current_scope])
+
+      true ->
+        socket.assigns[:current_user]
     end
   end
 

--- a/lib/permit_phoenix/types.ex
+++ b/lib/permit_phoenix/types.ex
@@ -12,6 +12,7 @@ defmodule Permit.Phoenix.Types do
 
   # Phoenix LiveView-specific types
   @type socket :: Phoenix.LiveView.Socket.t()
+  @type session :: map()
   @type hook_outcome :: {:halt, socket()} | {:cont, socket()} | no_return()
   @type live_authorization_result :: {:authorized | :unauthorized | :not_found, socket()}
 
@@ -38,6 +39,11 @@ defmodule Permit.Phoenix.Types do
   """
   @type handle_unauthorized :: (Types.action_group(), conn() -> conn())
 
+  @typedoc """
+  Maps the current Phoenix scope to the subject.
+  """
+  @type scope_subject :: (map() -> Types.subject()) | atom()
+
   if @permit_ecto_available? do
     @typedoc """
     - `:authorization_module` -- (Required) The app's authorization module that uses `use Permit`.
@@ -47,7 +53,7 @@ defmodule Permit.Phoenix.Types do
     - `id_param_name` -- (Required, if singular record actions are present) The parameter name used to look for IDs of resources, passed to the loader function or the repo.
     - `fallback_path` -- (Optional) A string denoting redirect path when unauthorized. Defaults to "/".
     - `error_msg` -- (Optional) An error message to put into the flash when unauthorizd. Defaults to "You do not have permission to perform this action."
-    - `handle_unauthorized - (Optional) A function taking (conn), performing specific action when authorization is not successful. Defaults to redirecting to :fallback_path.
+    - `handle_unauthorized` - (Optional) A function taking (action, conn), performing specific action when authorization is not successful. Defaults to redirecting to :fallback_path.
     """
 
     @type plug_opts :: [

--- a/test/permit/ecto_live_view_test.exs
+++ b/test/permit/ecto_live_view_test.exs
@@ -6,7 +6,7 @@ defmodule Permit.EctoLiveViewTest do
   import Phoenix.LiveViewTest
 
   alias Permit.EctoLiveViewTest.{Endpoint, HooksLive}
-  alias Permit.EctoFakeApp.{Item, Repo, User}
+  alias Permit.EctoFakeApp.{Item, Repo}
 
   @not_found_message ~r/Expected at least one result but got none/
 
@@ -29,14 +29,6 @@ defmodule Permit.EctoLiveViewTest do
       assigns = get_assigns(lv)
 
       assert :unauthorized not in Map.keys(assigns)
-    end
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
     end
 
     test "can do :index on items", %{conn: conn} do
@@ -84,14 +76,6 @@ defmodule Permit.EctoLiveViewTest do
 
   describe "owner" do
     setup [:owner_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/items")
@@ -183,14 +167,6 @@ defmodule Permit.EctoLiveViewTest do
       assigns = get_assigns(lv)
 
       assert :unauthorized in Map.keys(assigns)
-    end
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
     end
 
     test "can do :index on items", %{conn: conn} do

--- a/test/permit/ecto_live_view_with_loader_test.exs
+++ b/test/permit/ecto_live_view_with_loader_test.exs
@@ -6,7 +6,7 @@ defmodule Permit.EctoLiveViewWithLoaderTest do
   import Phoenix.LiveViewTest
 
   alias Permit.EctoLiveViewTest.{Endpoint, HooksWithLoaderLive}
-  alias Permit.EctoFakeApp.{Item, Repo, User}
+  alias Permit.EctoFakeApp.{Item, Repo}
 
   @endpoint Endpoint
 
@@ -18,14 +18,6 @@ defmodule Permit.EctoLiveViewWithLoaderTest do
 
   describe "admin" do
     setup [:admin_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/books")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/books")
@@ -74,14 +66,6 @@ defmodule Permit.EctoLiveViewWithLoaderTest do
 
   describe "owner" do
     setup [:owner_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/books")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/books")
@@ -142,14 +126,6 @@ defmodule Permit.EctoLiveViewWithLoaderTest do
 
   describe "inspector" do
     setup [:inspector_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/books")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/books")

--- a/test/permit/non_ecto_live_view_test.exs
+++ b/test/permit/non_ecto_live_view_test.exs
@@ -5,7 +5,7 @@ defmodule Permit.NonEctoLiveViewTest do
   import Phoenix.LiveViewTest
 
   alias Permit.NonEctoLiveViewTest.{Endpoint, HooksLive}
-  alias Permit.NonEctoFakeApp.{Item, User}
+  alias Permit.NonEctoFakeApp.Item
   alias Permit.NonEctoFakeApp.Item.Context, as: ItemContext
   alias Permit.NonEctoFakeApp.User.Context, as: UserContext
 
@@ -20,14 +20,6 @@ defmodule Permit.NonEctoLiveViewTest do
 
   describe "admin" do
     setup [:admin_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/items")
@@ -68,14 +60,6 @@ defmodule Permit.NonEctoLiveViewTest do
 
   describe "owner" do
     setup [:owner_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/items")
@@ -148,14 +132,6 @@ defmodule Permit.NonEctoLiveViewTest do
 
   describe "inspector" do
     setup [:inspector_role, :init_session]
-
-    test "sets :current_user assign", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, "/items")
-
-      assigns = get_assigns(lv)
-
-      assert %{current_user: %User{id: 1}} = assigns
-    end
 
     test "can do :index on items", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/items")

--- a/test/support/ecto_fake_app/scope.ex
+++ b/test/support/ecto_fake_app/scope.ex
@@ -1,0 +1,12 @@
+defmodule Permit.EctoFakeApp.Scope do
+  @moduledoc false
+  alias Permit.EctoFakeApp.User
+
+  defstruct user: nil
+
+  def for_user(%User{} = user) do
+    %__MODULE__{user: user}
+  end
+
+  def for_user(nil), do: nil
+end

--- a/test/support/ecto_fake_app/session_controller.ex
+++ b/test/support/ecto_fake_app/session_controller.ex
@@ -3,6 +3,7 @@ defmodule Permit.EctoFakeApp.SessionController do
   use Phoenix.Controller
 
   alias Permit.EctoFakeApp.User
+  alias Permit.EctoFakeApp.Scope
 
   def create(conn, params) do
     user =
@@ -11,7 +12,7 @@ defmodule Permit.EctoFakeApp.SessionController do
       |> Map.new()
       |> Map.put(:__struct__, User)
 
-    assign(conn, :current_user, user)
+    assign(conn, :current_scope, Scope.for_user(user))
   end
 
   defp parse_param({k, list}) when is_list(list),

--- a/test/support/ecto_live_view_test/hooks_live.ex
+++ b/test/support/ecto_live_view_test/hooks_live.ex
@@ -1,7 +1,7 @@
 defmodule Permit.EctoLiveViewTest.HooksLive do
   use Phoenix.LiveView, namespace: Permit
 
-  alias Permit.EctoFakeApp.{Authorization, Item, User}
+  alias Permit.EctoFakeApp.{Authorization, Item}
   alias Permit.EctoFakeApp.Item.Context
 
   use Permit.Phoenix.LiveView,
@@ -28,14 +28,6 @@ defmodule Permit.EctoLiveViewTest.HooksLive do
 
   @impl Permit.Phoenix.LiveView
   def handle_unauthorized(_action, socket), do: {:cont, assign(socket, :unauthorized, true)}
-
-  @impl Permit.Phoenix.LiveView
-  def fetch_subject(_socket, session) do
-    case session["token"] do
-      "valid_token" -> %User{id: 1, roles: session["roles"] || []}
-      _ -> nil
-    end
-  end
 
   @impl true
   @spec render(any) :: Phoenix.LiveView.Rendered.t()

--- a/test/support/ecto_live_view_test/live_router.ex
+++ b/test/support/ecto_live_view_test/live_router.ex
@@ -1,27 +1,35 @@
 defmodule Permit.EctoLiveViewTest.LiveRouter do
   @moduledoc false
   use Phoenix.Router
+
   import Phoenix.LiveView.Router
+
   alias Permit.EctoFakeApp.ActionPluralityLive
   alias Permit.EctoLiveViewTest.HooksWithLoaderLive
   alias Permit.EctoLiveViewTest.HooksLive
   alias Permit.EctoLiveViewTest.HooksWithCustomOptsLive
 
-  live_session :authenticated, on_mount: Permit.Phoenix.LiveView.AuthorizeHook do
-    live("/items", HooksLive, :index)
-    live("/items/new", HooksLive, :new)
-    live("/items/:id/edit", HooksLive, :edit)
-    live("/items/:id", HooksLive, :show)
+  scope "/" do
+    live_session :authenticated,
+      on_mount: [
+        {Permit.EctoLiveViewTest.UserAuth, :mount_current_scope},
+        Permit.Phoenix.LiveView.AuthorizeHook
+      ] do
+      live("/items", HooksLive, :index)
+      live("/items/new", HooksLive, :new)
+      live("/items/:id/edit", HooksLive, :edit)
+      live("/items/:id", HooksLive, :show)
 
-    live("/items_custom/:id/edit", HooksWithCustomOptsLive, :edit)
+      live("/items_custom/:id/edit", HooksWithCustomOptsLive, :edit)
 
-    live("/books", HooksWithLoaderLive, :index)
-    live("/books/new", HooksWithLoaderLive, :new)
-    live("/books/:id/edit", HooksWithLoaderLive, :edit)
-    live("/books/:id", HooksWithLoaderLive, :show)
+      live("/books", HooksWithLoaderLive, :index)
+      live("/books/new", HooksWithLoaderLive, :new)
+      live("/books/:id/edit", HooksWithLoaderLive, :edit)
+      live("/books/:id", HooksWithLoaderLive, :show)
 
-    live("/live_action_plurality", ActionPluralityLive, :list)
-    live("/live_action_plurality/:id", ActionPluralityLive, :view)
+      live("/live_action_plurality", ActionPluralityLive, :list)
+      live("/live_action_plurality/:id", ActionPluralityLive, :view)
+    end
   end
 
   def session(%Plug.Conn{}, extra), do: Map.merge(extra, %{"called" => true})

--- a/test/support/ecto_live_view_test/user_auth.ex
+++ b/test/support/ecto_live_view_test/user_auth.ex
@@ -1,0 +1,25 @@
+defmodule Permit.EctoLiveViewTest.UserAuth do
+  @moduledoc false
+
+  alias Permit.EctoFakeApp.Scope
+  alias Permit.EctoFakeApp.User
+
+  # Mimic default scope fetching process of Phoenix 1.8+
+  def on_mount(:mount_current_scope, _params, session, socket) do
+    {:cont, mount_current_scope(socket, session)}
+  end
+
+  def mount_current_scope(socket, session) do
+    Phoenix.Component.assign_new(socket, :current_scope, fn ->
+      user = user_from_session(session)
+      Scope.for_user(user)
+    end)
+  end
+
+  def user_from_session(session) do
+    case session["token"] do
+      "valid_token" -> %User{id: 1, roles: session["roles"] || []}
+      _ -> nil
+    end
+  end
+end

--- a/test/support/non_ecto_fake_app/item_controller_using_loader.ex
+++ b/test/support/non_ecto_fake_app/item_controller_using_loader.ex
@@ -6,7 +6,8 @@ defmodule Permit.NonEctoFakeApp.ItemControllerUsingLoader do
 
   use Permit.Phoenix.Controller,
     authorization_module: Authorization,
-    resource_module: Item
+    resource_module: Item,
+    use_scope?: false
 
   def index(conn, _params), do: text(conn, "listing all items")
   def show(conn, _params), do: text(conn, inspect(conn.assigns[:loaded_resource]))


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

Fixes #33 

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

### Test Environment
- [ ] Elixir version: <!-- e.g., 1.17.0 -->
- [ ] OTP version: <!-- e.g., 27 -->
- [ ] Phoenix version: <!-- e.g., 1.7.0 -->
- [ ] LiveView version: <!-- e.g., 0.20.0 -->
- [ ] Database (if applicable): <!-- e.g., PostgreSQL 14 -->

### Test Cases
- [ ] All existing tests pass
- [ ] New tests added for new functionality at appropriate levels
- [ ] Manual testing performed
- [ ] Controller integration tests (if applicable)
- [ ] LiveView integration tests (if applicable)
- [ ] Router integration tests (if applicable)

### Test Commands Run
```bash
# List the commands you ran to test
mix test
MIX_ENV=test mix credo
MIX_ENV=test mix dialyzer
```

## Documentation

- [x] Updated README.md (if applicable)
- [x] Updated documentation comments (with examples for new features)
- [x] Updated CHANGELOG.md (if applicable)
- [ ] Updated controller/LiveView usage examples (if applicable)

## Code Quality

- [ ] Code follows the existing style conventions
- [ ] Self-review of the code has been performed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] No new linting warnings introduced
- [ ] No new Dialyzer warnings introduced
- [ ] Follows Phoenix and LiveView conventions

## Phoenix/LiveView Specific

- [ ] Controller changes properly handle conn state
- [ ] LiveView changes properly handle socket state
- [ ] Router integration works correctly
- [ ] Error handling follows Phoenix patterns
- [ ] Authorization flows work as expected

## Backward Compatibility

- [ ] This change is backward compatible
- [ ] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes
<!-- If there are breaking changes, describe them here -->

## Performance Impact

- [ ] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (please describe)

### Performance Notes
<!-- Describe any performance considerations -->

## Security Considerations

- [ ] No security impact
- [ ] Security improvement
- [ ] Potential security impact (please describe)

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

```elixir
# Example usage of new feature
defmodule MyAppWeb.ArticleController do
  use Permit.Phoenix.Controller,
    authorization_module: MyApp.Authorization,
    resource_module: MyApp.Article

  # New functionality here
end
```

## Checklist

- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

---

<!-- Thank you for contributing to Permit.Phoenix! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Phoenix Scopes–based subject resolution (default) with new callbacks, updates hooks/types/docs/tests, and removes the LiveView fetch_subject requirement.
> 
> - **Core/Behavior**:
>   - Add Phoenix Scopes integration; subject now resolves from `@current_scope` by default via `use_scope?/0` and `scope_subject/1`.
>   - LiveView no longer requires `fetch_subject/2` and no longer assigns `:current_user` (breaking change).
>   - New types: `Types.session` and `scope_subject`.
> - **LiveView**:
>   - Extend callbacks/options: `use_scope?/0`, `scope_subject/1`; propagate through `__using__` and `@optional_callbacks`.
>   - Update `AuthorizeHook` to resolve subject via scope/session and authorize in `on_mount`, `handle_params`, and event flow.
> - **Controller**:
>   - Add `use_scope?/0` and `scope_subject/1` callbacks; default to `current_scope.user` with fallback to `current_user`.
>   - `fetch_subject/1` now respects scope settings; example shows opting out with `use_scope?: false`.
> - **Docs/Changelog**:
>   - CHANGELOG notes breaking changes and new Scopes feature.
>   - README adds detailed setup and configuration for Phoenix Scopes and clarifies LiveView usage.
> - **Tests/Support**:
>   - Update test routers to mount `current_scope`; add `Scope` struct and `UserAuth` hook.
>   - Remove `:current_user` assign assertions; adapt tests to new subject resolution and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59622ed13b0a5e86528b4f26fb4f77708cb9563c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->