### PR TITLE
Retry Codecov upload on failure

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -107,6 +107,16 @@ jobs:
       - name: Run tests
         run: mix coveralls.json
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        uses: nick-fields/retry@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          timeout_minutes: 2
+          max_attempts: 3
+          retry_on: error
+          command: |
+            curl -LO https://cli.codecov.io/latest/linux/codecov
+            if [ ! -f codecov ] || [ ! -s codecov ]; then
+              echo "Download failed or file is empty"
+              exit 1
+            fi
+            chmod +x codecov
+            ./codecov upload-process -t ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace Codecov action with a retryable CLI upload in the Elixir CI workflow; minor YAML normalization.
> 
> - **CI Workflow (`.github/workflows/elixir.yml`)**:
>   - **Coverage upload**: Replace `codecov/codecov-action` with `nick-fields/retry` running the Codecov CLI to retry uploads on failure.
>   - *YAML cleanup*: Normalize quoting and array formatting; no logic changes to lint/build steps or matrix besides formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f58f230809abf3f65bf10bdfb97694264f94b9a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->