### PR TITLE
49 improve authorization of create actions

### DIFF
--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -330,6 +330,48 @@ defmodule Permit.Phoenix.Controller do
         end
     """
     @callback finalize_query(Ecto.Query.t(), Types.resolution_context()) :: Ecto.Query.t()
+
+    @doc ~S"""
+    Wraps a record creating callback in a database transaction and verifies
+    that the created record satisfies the current user's authorization conditions.
+
+    This is used for `:create` actions where permissions are defined with
+    field-level conditions (e.g. `create(Article, user_id: user.id)`). The plug
+    only performs a module-level check, so the conditions are not verified against
+    the actual record.
+
+    ## Usage
+
+        def create(conn, %{"article" => params}) do
+          case authorize_with_transaction(conn, fn ->
+            Repo.insert(Article.changeset(%Article{}, params))
+          end) do
+            {:ok, article} -> redirect(conn, to: ~p"/articles/#{article}")
+            {:error, changeset} -> render(conn, :new, changeset: changeset)
+            {:unauthorized, conn} -> conn
+          end
+        end
+
+    ## Options
+
+      * `:action` - override the action name (defaults to `Phoenix.Controller.action_name(conn)`)
+
+    ## Return values
+
+      * `{:ok, record}` - the callback returned `{:ok, record}` and authorization passed
+      * `{:error, changeset}` - the callback returned `{:error, changeset}` (no auth check performed)
+      * `{:unauthorized, conn}` - the callback returned `{:ok, record}` but authorization failed;
+        the transaction was rolled back and `conn` is halted via `c:handle_unauthorized/2`
+    """
+    @callback authorize_with_transaction(PhoenixTypes.conn(), (-> {:ok, term()} | {:error, term()})) ::
+                {:ok, term()} | {:error, term()} | {:unauthorized, PhoenixTypes.conn()}
+
+    @callback authorize_with_transaction(
+                PhoenixTypes.conn(),
+                (-> {:ok, term()} | {:error, term()}),
+                keyword()
+              ) ::
+                {:ok, term()} | {:error, term()} | {:unauthorized, PhoenixTypes.conn()}
   end
 
   @doc ~S"""
@@ -550,6 +592,12 @@ defmodule Permit.Phoenix.Controller do
                         if(@permit_ecto_available?,
                           do: {:finalize_query, 2}
                         ),
+                        if(@permit_ecto_available?,
+                          do: {:authorize_with_transaction, 2}
+                        ),
+                        if(@permit_ecto_available?,
+                          do: {:authorize_with_transaction, 3}
+                        ),
                         handle_unauthorized: 2,
                         skip_preload: 0,
                         preload_actions: 0,
@@ -641,6 +689,16 @@ defmodule Permit.Phoenix.Controller do
         @impl true
         def finalize_query(query, resolution_context),
           do: unquote(__MODULE__).finalize_query(query, resolution_context, unquote(opts))
+
+        @impl true
+        def authorize_with_transaction(conn, callback, opts \\ []) do
+          Permit.Phoenix.Controller.authorize_with_transaction(
+            conn,
+            callback,
+            opts,
+            __MODULE__
+          )
+        end
       end
 
       @impl true
@@ -685,6 +743,12 @@ defmodule Permit.Phoenix.Controller do
           ),
           if(unquote(@permit_ecto_available?),
             do: {:finalize_query, 2}
+          ),
+          if(unquote(@permit_ecto_available?),
+            do: {:authorize_with_transaction, 2}
+          ),
+          if(unquote(@permit_ecto_available?),
+            do: {:authorize_with_transaction, 3}
           ),
           handle_unauthorized: 2,
           skip_preload: 0,
@@ -801,6 +865,39 @@ defmodule Permit.Phoenix.Controller do
 
     @doc false
     def finalize_query(query, %{}, _), do: query
+
+    @doc false
+    def authorize_with_transaction(conn, callback, opts, controller_module) do
+      action = opts[:action] || Phoenix.Controller.action_name(conn)
+      subject = controller_module.fetch_subject(conn)
+      auth_module = controller_module.authorization_module()
+      repo = auth_module.repo()
+
+      repo.transaction(fn ->
+        case callback.() do
+          {:ok, record} -> verify_or_rollback(auth_module, repo, subject, action, record)
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, record} ->
+          {:ok, record}
+
+        {:error, :unauthorized} ->
+          {:unauthorized, controller_module.handle_unauthorized(action, conn)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+
+    defp verify_or_rollback(auth_module, repo, subject, action, record) do
+      if auth_module.can(subject) |> Permit.verify_record(action, record) do
+        record
+      else
+        repo.rollback(:unauthorized)
+      end
+    end
   end
 
   @doc false

--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -347,31 +347,42 @@ defmodule Permit.Phoenix.Controller do
             Repo.insert(Article.changeset(%Article{}, params))
           end) do
             {:ok, article} -> redirect(conn, to: ~p"/articles/#{article}")
-            {:error, changeset} -> render(conn, :new, changeset: changeset)
-            {:unauthorized, conn} -> conn
+            {:error, %Ecto.Changeset{} = changeset} -> render(conn, :new, changeset: changeset)
+            {:error, conn} -> conn
           end
         end
 
     ## Options
 
       * `:action` - override the action name (defaults to `Phoenix.Controller.action_name(conn)`)
+      * `:on_unauthorized` - custom unauthorized handler function `(action, conn -> conn)`.
+        Called instead of `c:handle_unauthorized/2` when the created record fails authorization.
+        Must halt the conn.
 
     ## Return values
 
       * `{:ok, record}` - the callback returned `{:ok, record}` and authorization passed
-      * `{:error, changeset}` - the callback returned `{:error, changeset}` (no auth check performed)
-      * `{:unauthorized, conn}` - the callback returned `{:ok, record}` but authorization failed;
+      * `{:error, reason}` - the callback returned `{:error, reason}` (no auth check performed)
+      * `{:error, conn}` - the callback returned `{:ok, record}` but authorization failed;
         the transaction was rolled back and `conn` is halted via `c:handle_unauthorized/2`
+        (or the `:on_unauthorized` handler if provided)
+
+    ## Caveats
+
+    The callback runs inside `Repo.transaction/1`. Only database operations are
+    rolled back when authorization fails. Side effects such as sending emails,
+    publishing PubSub messages, or calling external APIs will **not** be undone.
+    Keep the callback limited to database operations.
     """
     @callback authorize_with_transaction(PhoenixTypes.conn(), (-> {:ok, term()} | {:error, term()})) ::
-                {:ok, term()} | {:error, term()} | {:unauthorized, PhoenixTypes.conn()}
+                {:ok, term()} | {:error, term()}
 
     @callback authorize_with_transaction(
                 PhoenixTypes.conn(),
                 (-> {:ok, term()} | {:error, term()}),
                 keyword()
               ) ::
-                {:ok, term()} | {:error, term()} | {:unauthorized, PhoenixTypes.conn()}
+                {:ok, term()} | {:error, term()}
   end
 
   @doc ~S"""
@@ -884,7 +895,11 @@ defmodule Permit.Phoenix.Controller do
           {:ok, record}
 
         {:error, :unauthorized} ->
-          {:unauthorized, controller_module.handle_unauthorized(action, conn)}
+          handler =
+            opts[:on_unauthorized] ||
+              fn action, conn -> controller_module.handle_unauthorized(action, conn) end
+
+          {:error, handler.(action, conn)}
 
         {:error, reason} ->
           {:error, reason}

--- a/lib/permit_phoenix/live_view.ex
+++ b/lib/permit_phoenix/live_view.ex
@@ -574,6 +574,84 @@ defmodule Permit.Phoenix.LiveView do
         end
     """
     @callback finalize_query(Ecto.Query.t(), Types.resolution_context()) :: Ecto.Query.t()
+
+    @doc ~S"""
+    Wraps a record creating callback in a database transaction and verifies
+    that the created record satisfies the current user's authorization conditions.
+
+    This is used for `:create` actions where permissions are defined with
+    field level conditions (e.g. `create(Article, user_id: user.id)`). The hook
+    only performs a module level check, so the conditions are not verified against
+    the actual record.
+
+    ## Usage
+
+    The `:action` defaults to `socket.assigns.live_action` (e.g. `:new`), which
+    transitively resolves to `:create` through Permit's action grouping.
+
+        @impl true
+        @permit_action :create
+        def handle_event("save", %{"article" => article_params}, socket) do
+          article_params = Map.put(article_params, "user_id", socket.assigns.current_scope.user.id)
+
+          case authorize_with_transaction(socket, fn ->
+            Blog.create_article(article_params)
+          end) do
+            {:ok, article} ->
+              {:noreply,
+               socket
+               |> put_flash(:info, "Article created successfully")
+               |> push_navigate(to: ~p"/articles/#{article}")}
+
+            {:error, %Ecto.Changeset{} = changeset} ->
+              {:noreply, assign(socket, :form, to_form(changeset))}
+
+            {:error, socket} ->
+              {:noreply, socket}
+          end
+        end
+
+    ## Options
+
+      * `:action` - override the action name used for the record-level authorization check.
+        Defaults to `socket.assigns.live_action`, which is the route's `:live_action` (e.g.
+        `:new` or `:edit`). This works correctly thanks to Permit's transitive action
+        resolution — `:new` transitively checks `:create` permissions. Override this if
+        your action grouping differs from the defaults.
+      * `:subject` - override the subject used for authorization. By default, the subject
+        is retrieved from `socket.assigns` using `use_scope?/0` (i.e. `current_scope`) or
+        `current_user`. Use this option if you have a custom `c:fetch_subject/2` override
+        that relies on session data, since session is not available in `handle_event` context.
+      * `:on_unauthorized` - custom unauthorized handler function `(action, socket -> socket)`.
+        Called instead of `c:handle_unauthorized/2` when the created record fails authorization.
+
+    ## Return values
+
+      * `{:ok, record}` - the callback returned `{:ok, record}` and authorization passed
+      * `{:error, reason}` - the callback returned `{:error, reason}` (no auth check performed)
+      * `{:error, socket}` - the callback returned `{:ok, record}` but authorization failed;
+        the transaction was rolled back and `socket` has been handled by `c:handle_unauthorized/2`
+        (or the `:on_unauthorized` handler if provided)
+
+    ## Caveats
+
+    The callback runs inside `Repo.transaction/1`. Only database operations are
+    rolled back when authorization fails. Side effects such as sending emails,
+    publishing PubSub messages, or calling external APIs will **not** be undone.
+    Keep the callback limited to database operations.
+    """
+    @callback authorize_with_transaction(
+                PhoenixTypes.socket(),
+                (-> {:ok, term()} | {:error, term()})
+              ) ::
+                {:ok, term()} | {:error, term()}
+
+    @callback authorize_with_transaction(
+                PhoenixTypes.socket(),
+                (-> {:ok, term()} | {:error, term()}),
+                keyword()
+              ) ::
+                {:ok, term()} | {:error, term()}
   end
 
   @doc ~S"""
@@ -1007,6 +1085,12 @@ defmodule Permit.Phoenix.LiveView do
                         if(@permit_ecto_available?,
                           do: {:finalize_query, 2}
                         ),
+                        if(@permit_ecto_available?,
+                          do: {:authorize_with_transaction, 2}
+                        ),
+                        if(@permit_ecto_available?,
+                          do: {:authorize_with_transaction, 3}
+                        ),
                         handle_unauthorized: 2,
                         skip_preload: 0,
                         preload_actions: 0,
@@ -1113,6 +1197,16 @@ defmodule Permit.Phoenix.LiveView do
         @impl true
         def finalize_query(query, resolution_context),
           do: unquote(__MODULE__).finalize_query(query, resolution_context, unquote(opts))
+
+        @impl true
+        def authorize_with_transaction(socket, callback, opts \\ []) do
+          Permit.Phoenix.LiveView.authorize_with_transaction(
+            socket,
+            callback,
+            opts,
+            __MODULE__
+          )
+        end
       end
 
       @impl true
@@ -1180,6 +1274,12 @@ defmodule Permit.Phoenix.LiveView do
           ),
           if(unquote(@permit_ecto_available?),
             do: {:finalize_query, 2}
+          ),
+          if(unquote(@permit_ecto_available?),
+            do: {:authorize_with_transaction, 2}
+          ),
+          if(unquote(@permit_ecto_available?),
+            do: {:authorize_with_transaction, 3}
           ),
           handle_unauthorized: 2,
           skip_preload: 0,
@@ -1386,6 +1486,54 @@ defmodule Permit.Phoenix.LiveView do
 
     @doc false
     def finalize_query(query, %{}, _opts), do: query
+
+    @doc false
+    def authorize_with_transaction(socket, callback, opts, live_view_module) do
+      action = opts[:action] || socket.assigns.live_action
+      subject = opts[:subject] || get_subject_from_socket(socket, live_view_module)
+      auth_module = live_view_module.authorization_module()
+      repo = auth_module.repo()
+
+      repo.transaction(fn ->
+        case callback.() do
+          {:ok, record} -> verify_or_rollback(auth_module, repo, subject, action, record)
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, record} ->
+          {:ok, record}
+
+        {:error, :unauthorized} ->
+          handler =
+            opts[:on_unauthorized] ||
+              fn action, socket ->
+                {_halt_or_cont, socket} = live_view_module.handle_unauthorized(action, socket)
+                socket
+              end
+
+          {:error, handler.(action, socket)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+
+    defp get_subject_from_socket(socket, live_view_module) do
+      if live_view_module.use_scope?() do
+        live_view_module.scope_subject(socket.assigns[:current_scope])
+      else
+        socket.assigns[:current_user]
+      end
+    end
+
+    defp verify_or_rollback(auth_module, repo, subject, action, record) do
+      if auth_module.can(subject) |> Permit.verify_record(action, record) do
+        record
+      else
+        repo.rollback(:unauthorized)
+      end
+    end
   end
 
   @doc false

--- a/test/permit/ecto_plug_test.exs
+++ b/test/permit/ecto_plug_test.exs
@@ -258,6 +258,112 @@ defmodule Permit.EctoPlugTest do
     end
   end
 
+  describe "authorize_with_transaction" do
+    test "admin creates any item", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:admin]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "item" => %{"owner_id" => "2", "permission_level" => "7"}
+        })
+
+      assert conn.resp_body =~ "created item"
+      assert Repo.get_by(Item, owner_id: 2, permission_level: 7)
+    end
+
+    test "creator creates item with matching owner_id", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:creator]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "item" => %{"owner_id" => "1", "permission_level" => "5"}
+        })
+
+      assert conn.resp_body =~ "created item"
+      assert Repo.get_by(Item, owner_id: 1, permission_level: 5)
+    end
+
+    test "creator creates item with wrong owner_id, unauthorized, rolled back", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:creator]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "item" => %{"owner_id" => "2", "permission_level" => "5"}
+        })
+
+      assert_unauthorized(conn, "/?foo")
+      assert conn.halted
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 5)
+    end
+
+    test "validation error passes through", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:admin]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "item" => %{"permission_level" => "not_a_number"}
+        })
+
+      assert conn.resp_body =~ "validation error"
+    end
+
+    test "creator denied when action is overridden to update", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:creator]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "_authorize_as" => "update",
+          "item" => %{"owner_id" => "1", "permission_level" => "9"}
+        })
+
+      assert_unauthorized(conn, "/?foo")
+      assert conn.halted
+      refute Repo.get_by(Item, owner_id: 1, permission_level: 9)
+    end
+
+    test "owner succeeds when action is overridden to update with matching owner_id", %{
+      items: _items
+    } do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:owner]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "_authorize_as" => "update",
+          "item" => %{"owner_id" => "1", "permission_level" => "9"}
+        })
+
+      assert conn.resp_body =~ "created item"
+      assert Repo.get_by(Item, owner_id: 1, permission_level: 9)
+    end
+
+    test "owner denied when action is overridden to update with wrong owner_id", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:owner]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "_authorize_as" => "update",
+          "item" => %{"owner_id" => "2", "permission_level" => "9"}
+        })
+
+      assert_unauthorized(conn, "/?foo")
+      assert conn.halted
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 9)
+    end
+
+    test "admin succeeds when action is overridden to update", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:admin]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "_authorize_as" => "update",
+          "item" => %{"owner_id" => "2", "permission_level" => "9"}
+        })
+
+      assert conn.resp_body =~ "created item"
+      assert Repo.get_by(Item, owner_id: 2, permission_level: 9)
+    end
+  end
+
   defp assert_unauthorized(
          conn,
          fallback_path,

--- a/test/permit/ecto_plug_test.exs
+++ b/test/permit/ecto_plug_test.exs
@@ -362,6 +362,26 @@ defmodule Permit.EctoPlugTest do
       assert conn.resp_body =~ "created item"
       assert Repo.get_by(Item, owner_id: 2, permission_level: 9)
     end
+
+    test "on_unauthorized option overrides default handler", %{items: _items} do
+      conn = create_conn(Router, :post, "/sign_in", %{id: 1, roles: [:creator]})
+
+      conn =
+        call(conn, :post, "/items", %{
+          "_custom_unauthorized" => "true",
+          "item" => %{"owner_id" => "2", "permission_level" => "5"}
+        })
+
+      assert conn.halted
+
+      actual_msg =
+        get_in(conn.private, [:phoenix_flash, "error"]) ||
+          get_in(conn.assigns, [:flash, "error"])
+
+      assert actual_msg == "Custom denied."
+      assert Map.new(conn.resp_headers)["location"] == "/custom_denied"
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 5)
+    end
   end
 
   defp assert_unauthorized(

--- a/test/permit/ecto_transaction_live_view_test.exs
+++ b/test/permit/ecto_transaction_live_view_test.exs
@@ -1,0 +1,254 @@
+defmodule Permit.EctoTransactionLiveViewTest do
+  @moduledoc """
+  Tests for authorize_with_transaction in LiveView handle_event.
+  Mirrors the Controller authorize_with_transaction tests for LiveView context.
+  """
+  use Permit.RepoCase
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  alias Permit.EctoFakeApp.{Item, Repo}
+  alias Permit.EctoLiveViewTest.{Endpoint, TransactionLive}
+
+  @endpoint Endpoint
+
+  setup do
+    %{users: users, items: items} = Repo.seed_data!()
+
+    {:ok, %{users: users, items: items}}
+  end
+
+  describe "admin creates any item" do
+    setup [:admin_role, :init_session]
+
+    test "admin creates item with any owner_id", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "item" => %{"owner_id" => "2", "permission_level" => "7"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Item{owner_id: 2, permission_level: 7} = assigns.created_item
+      assert Repo.get_by(Item, owner_id: 2, permission_level: 7)
+    end
+  end
+
+  describe "creator creates item" do
+    setup [:creator_role, :init_session]
+
+    test "creator creates item with matching owner_id", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "item" => %{"owner_id" => "1", "permission_level" => "5"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Item{owner_id: 1, permission_level: 5} = assigns.created_item
+      assert Repo.get_by(Item, owner_id: 1, permission_level: 5)
+    end
+
+    test "creator creates item with wrong owner_id, unauthorized, rolled back", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "item" => %{"owner_id" => "2", "permission_level" => "5"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert assigns[:unauthorized] == true
+      refute Map.has_key?(assigns, :created_item)
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 5)
+    end
+  end
+
+  describe "validation error" do
+    setup [:admin_role, :init_session]
+
+    test "validation error passes through", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "item" => %{"permission_level" => "not_a_number"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Ecto.Changeset{} = assigns.changeset_error
+      refute Map.has_key?(assigns, :created_item)
+    end
+  end
+
+  describe "action override" do
+    setup [:creator_role, :init_session]
+
+    test "creator denied when action is overridden to update", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_authorize_as" => "update",
+        "item" => %{"owner_id" => "1", "permission_level" => "9"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert assigns[:unauthorized] == true
+      refute Map.has_key?(assigns, :created_item)
+      refute Repo.get_by(Item, owner_id: 1, permission_level: 9)
+    end
+  end
+
+  describe "action override with owner role" do
+    setup [:owner_role, :init_session]
+
+    test "owner succeeds when action is overridden to update with matching owner_id", %{
+      conn: conn
+    } do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_authorize_as" => "update",
+        "item" => %{"owner_id" => "1", "permission_level" => "9"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Item{owner_id: 1, permission_level: 9} = assigns.created_item
+      assert Repo.get_by(Item, owner_id: 1, permission_level: 9)
+    end
+
+    test "owner denied when action is overridden to update with wrong owner_id", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_authorize_as" => "update",
+        "item" => %{"owner_id" => "2", "permission_level" => "9"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert assigns[:unauthorized] == true
+      refute Map.has_key?(assigns, :created_item)
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 9)
+    end
+  end
+
+  describe "on_unauthorized option" do
+    setup [:creator_role, :init_session]
+
+    test "on_unauthorized option overrides default handler", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_custom_unauthorized" => "true",
+        "item" => %{"owner_id" => "2", "permission_level" => "5"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert assigns[:custom_unauthorized] == true
+      # Default handler should NOT have been called
+      refute Map.has_key?(assigns, :unauthorized)
+      refute Repo.get_by(Item, owner_id: 2, permission_level: 5)
+    end
+  end
+
+  describe "admin action override to update" do
+    setup [:admin_role, :init_session]
+
+    test "admin succeeds when action is overridden to update", %{conn: conn} do
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_authorize_as" => "update",
+        "item" => %{"owner_id" => "2", "permission_level" => "9"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Item{owner_id: 2, permission_level: 9} = assigns.created_item
+      assert Repo.get_by(Item, owner_id: 2, permission_level: 9)
+    end
+  end
+
+  describe "subject option" do
+    setup [:admin_role, :init_session]
+
+    test "subject option overrides default subject resolution", %{conn: conn} do
+      # User 1 is logged in (admin), but we override subject to User{id: 2, roles: [:creator]}.
+      # :creator has create(Item, owner_id: user.id), so subject User{id: 2}
+      # can only create items with owner_id: 2.
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      # Create item with owner_id: 2, subject overridden to user 2 - should succeed
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_subject_id" => "2",
+        "item" => %{"owner_id" => "2", "permission_level" => "3"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert %Item{owner_id: 2, permission_level: 3} = assigns.created_item
+      assert Repo.get_by(Item, owner_id: 2, permission_level: 3)
+    end
+
+    test "subject option - unauthorized when subject doesn't match", %{conn: conn} do
+      # Override subject to User{id: 2, roles: [:creator]}, but try owner_id: 1
+      {:ok, liveview, _html} = live(conn, "/live/transaction_items/new")
+
+      liveview
+      |> element("#save")
+      |> render_click(%{
+        "_subject_id" => "2",
+        "item" => %{"owner_id" => "1", "permission_level" => "3"}
+      })
+
+      assigns = get_assigns(liveview)
+      assert assigns[:unauthorized] == true
+      refute Map.has_key?(assigns, :created_item)
+      refute Repo.get_by(Item, owner_id: 1, permission_level: 3)
+    end
+  end
+
+  # Helper functions
+
+  defp admin_role(context) do
+    {:ok, Map.put(context, :roles, [:admin])}
+  end
+
+  defp creator_role(context) do
+    {:ok, Map.put(context, :roles, [:creator])}
+  end
+
+  defp owner_role(context) do
+    {:ok, Map.put(context, :roles, [:owner])}
+  end
+
+  defp init_session(%{roles: roles}) do
+    {:ok,
+     conn:
+       Plug.Test.init_test_session(
+         build_conn(),
+         %{"token" => "valid_token", roles: roles}
+       )}
+  end
+
+  defp get_assigns(liveview) do
+    TransactionLive.run(liveview, fn socket -> {:reply, socket.assigns, socket} end)
+  end
+end

--- a/test/support/ecto_fake_app/item_controller_using_repo.ex
+++ b/test/support/ecto_fake_app/item_controller_using_repo.ex
@@ -20,14 +20,26 @@ defmodule Permit.EctoFakeApp.ItemControllerUsingRepo do
         _ -> []
       end
 
+    auth_opts =
+      if params["_custom_unauthorized"] do
+        Keyword.put(auth_opts, :on_unauthorized, fn _action, conn ->
+          conn
+          |> put_flash(:error, "Custom denied.")
+          |> redirect(to: "/custom_denied")
+          |> halt()
+        end)
+      else
+        auth_opts
+      end
+
     case authorize_with_transaction(
            conn,
            fn -> Repo.insert(Item.changeset(%Item{}, item_params)) end,
            auth_opts
          ) do
       {:ok, item} -> text(conn, "created item #{item.id}")
-      {:error, _changeset} -> text(conn, "validation error")
-      {:unauthorized, conn} -> conn
+      {:error, %Ecto.Changeset{}} -> text(conn, "validation error")
+      {:error, conn} -> conn
     end
   end
 

--- a/test/support/ecto_fake_app/item_controller_using_repo.ex
+++ b/test/support/ecto_fake_app/item_controller_using_repo.ex
@@ -2,7 +2,7 @@ defmodule Permit.EctoFakeApp.ItemControllerUsingRepo do
   @moduledoc false
   use Phoenix.Controller, formats: [html: "View"]
 
-  alias Permit.EctoFakeApp.{Authorization, Item}
+  alias Permit.EctoFakeApp.{Authorization, Item, Repo}
 
   use Permit.Phoenix.Controller,
     authorization_module: Authorization,
@@ -11,6 +11,25 @@ defmodule Permit.EctoFakeApp.ItemControllerUsingRepo do
     fallback_path: "/?foo"
 
   def index(conn, _params), do: text(conn, "listing all items")
+
+  def create(conn, %{"item" => item_params} = params) do
+    auth_opts =
+      case params["_authorize_as"] do
+        "update" -> [action: :update]
+        "create" -> [action: :create]
+        _ -> []
+      end
+
+    case authorize_with_transaction(
+           conn,
+           fn -> Repo.insert(Item.changeset(%Item{}, item_params)) end,
+           auth_opts
+         ) do
+      {:ok, item} -> text(conn, "created item #{item.id}")
+      {:error, _changeset} -> text(conn, "validation error")
+      {:unauthorized, conn} -> conn
+    end
+  end
 
   def show(conn, _params) do
     text(conn, inspect(conn.assigns[:loaded_resource]))

--- a/test/support/ecto_fake_app/permissions.ex
+++ b/test/support/ecto_fake_app/permissions.ex
@@ -20,6 +20,11 @@ defmodule Permit.EctoFakeApp.Permissions do
     |> all(Item, fn user, item -> item.owner_id == user.id end)
   end
 
+  def can(:creator = _role) do
+    permit()
+    |> create(Item, [user, _item], owner_id: user.id)
+  end
+
   def can(:inspector = _role) do
     permit()
     |> read(Item)

--- a/test/support/ecto_fake_app/router.ex
+++ b/test/support/ecto_fake_app/router.ex
@@ -10,6 +10,7 @@ defmodule Permit.EctoFakeApp.Router do
   alias Permit.EctoLiveViewTest.DefaultBehaviorLive
   alias Permit.EctoLiveViewTest.SaveEventLive
   alias Permit.EctoLiveViewTest.SaveEventNoReloadLive
+  alias Permit.EctoLiveViewTest.TransactionLive
 
   pipeline :browser do
     plug(Plug.Session,
@@ -77,6 +78,8 @@ defmodule Permit.EctoFakeApp.Router do
 
       live("/save_event_items/:id/edit", SaveEventLive, :edit)
       live("/save_event_no_reload_items/:id/edit", SaveEventNoReloadLive, :edit)
+
+      live("/transaction_items/new", TransactionLive, :new)
     end
   end
 end

--- a/test/support/ecto_live_view_test/live_router.ex
+++ b/test/support/ecto_live_view_test/live_router.ex
@@ -11,6 +11,7 @@ defmodule Permit.EctoLiveViewTest.LiveRouter do
   alias Permit.EctoLiveViewTest.DefaultBehaviorLive
   alias Permit.EctoLiveViewTest.SaveEventLive
   alias Permit.EctoLiveViewTest.SaveEventNoReloadLive
+  alias Permit.EctoLiveViewTest.TransactionLive
 
   scope "/" do
     live_session :authenticated,
@@ -40,6 +41,8 @@ defmodule Permit.EctoLiveViewTest.LiveRouter do
 
       live("/save_event_items/:id/edit", SaveEventLive, :edit)
       live("/save_event_no_reload_items/:id/edit", SaveEventNoReloadLive, :edit)
+
+      live("/transaction_items/new", TransactionLive, :new)
     end
   end
 

--- a/test/support/ecto_live_view_test/transaction_live.ex
+++ b/test/support/ecto_live_view_test/transaction_live.ex
@@ -1,0 +1,95 @@
+defmodule Permit.EctoLiveViewTest.TransactionLive do
+  @moduledoc """
+  LiveView for testing authorize_with_transaction in handle_event.
+  """
+  use Phoenix.LiveView, namespace: Permit
+
+  alias Permit.EctoFakeApp.{Authorization, Item, Repo}
+
+  use Permit.Phoenix.LiveView,
+    authorization_module: Authorization,
+    resource_module: Item
+
+  @impl Permit.Phoenix.LiveView
+  def handle_unauthorized(_action, socket), do: {:cont, assign(socket, :unauthorized, true)}
+
+  @impl true
+  @spec render(any) :: Phoenix.LiveView.Rendered.t()
+  def render(assigns) do
+    ~H"""
+    <div id="item-form">
+      <button id="save" phx-click="save">Save</button>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, mounted: true)}
+  end
+
+  @impl true
+  @permit_action :create
+  def handle_event("save", params, socket) do
+    item_params = params["item"] || %{}
+
+    # When _authorize_as is given, override the action explicitly.
+    # Otherwise, omit :action to test the default (live_action) path.
+    auth_opts =
+      case params["_authorize_as"] do
+        nil -> []
+        action_str -> [action: String.to_existing_atom(action_str)]
+      end
+
+    auth_opts =
+      if params["_custom_unauthorized"] do
+        Keyword.put(auth_opts, :on_unauthorized, fn _action, socket ->
+          assign(socket, :custom_unauthorized, true)
+        end)
+      else
+        auth_opts
+      end
+
+    # Allow tests to override the subject via _subject_id param.
+    # Constructs a User with the :creator role so SubjectMapping resolves properly.
+    auth_opts =
+      if subject_id = params["_subject_id"] do
+        Keyword.put(auth_opts, :subject, %Permit.EctoFakeApp.User{
+          id: String.to_integer(subject_id),
+          roles: [:creator]
+        })
+      else
+        auth_opts
+      end
+
+    case authorize_with_transaction(
+           socket,
+           fn -> Repo.insert(Item.changeset(%Item{}, item_params)) end,
+           auth_opts
+         ) do
+      {:ok, item} ->
+        {:noreply, assign(socket, :created_item, item)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :changeset_error, changeset)}
+
+      {:error, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_call({:run, func}, _, socket), do: func.(socket)
+
+  @impl true
+  def handle_info({:run, func}, socket), do: func.(socket)
+
+  def run(liveview, func) do
+    GenServer.call(liveview.pid, {:run, func})
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,6 +16,12 @@ Application.put_env(
 
 {:ok, _pid} = Permit.EctoFakeApp.Repo.start_link()
 
+# Advance item IDs past explicitly seeded values to avoid PK collisions
+# when tests insert rows without explicit IDs.
+Permit.EctoFakeApp.Repo.query!(
+  "SELECT setval(pg_get_serial_sequence('items', 'id'), GREATEST((SELECT COALESCE(MAX(id), 0) FROM items), 10000))"
+)
+
 # Code.require_file("ecto_migration.exs", __DIR__)
 
 # :ok = Ecto.Migrator.up(Permit.NonEctoFakeApp.Repo, 0, Ecto.Integration.Migration, log: false)


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does -->
This PR introduces `authorize_with_transaction` for controller create flows that need post insert authorization checks.

Final behavior in this PR:
- `authorize_with_transaction` returns only `{:ok, value}` or `{:error, reason}`
- Unauthorized post-create checks are returned as `{:error, conn}` (after calling unauthorized handler)
- Optional `:on_unauthorized` handler can override `handle_unauthorized/2` for this flow

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test improvements
- [ ] CI/CD improvements

## Related Issues

Closes #49.

## Changes Made

<!-- List the main changes made in this PR -->

- Added `authorize_with_transaction/2,3` callback API and default implementation in `Permit.Phoenix.Controller` (Ecto enabled path).
- Added transactional post create authorization verification with rollback on unauthorized records.
- Added optional `:action` override support for authorization context.
- Added optional `:on_unauthorized` option to customize unauthorized handling for this flow.
- Simplified return contract from `{:ok, _} | {:error, _} | {:unauthorized, conn}` to `{:ok, _} | {:error, _}`.
- Updated docs/examples and callback specs to reflect the simplified return contract.
- Updated test support controller matching to distinguish:
  - `{:error, %Ecto.Changeset{}}` (validation)
  - `{:error, conn}` (unauthorized)
- Added integration tests covering success, validation failure, unauthorized rollback, action override, and custom unauthorized handling.
- Added test helper DB sequence adjustment to avoid PK collisions in insertion-heavy tests.

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Environment
- [x] Elixir version: 1.18.4
- [x] OTP version: 28
- [x] Phoenix version: 1.8.1
- [x] LiveView version: 1.1.17
- [x] Database (if applicable): PostgreSQL

### Test Cases
- [x] All existing tests pass
- [x] New tests added for new functionality at appropriate levels
- [x] Manual testing performed
- [x] Controller integration tests (if applicable)
- [ ] LiveView integration tests (if applicable)
- [x] Router integration tests (if applicable)

### Test Commands Run
```bash
# List the commands you ran to test
mix test
MIX_ENV=test mix credo
MIX_ENV=test mix dialyzer
```

## Documentation

- [ ] Updated README.md (if applicable)
- [x] Updated documentation comments (with examples for new features)
- [ ] Updated CHANGELOG.md (if applicable)
- [x] Updated controller/LiveView usage examples (if applicable)

## Code Quality

- [x] Code follows the existing style conventions
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] No new linting warnings introduced
- [x] No new Dialyzer warnings introduced
- [x] Follows Phoenix and LiveView conventions

## Phoenix/LiveView Specific

- [x] Controller changes properly handle conn state
- [ ] LiveView changes properly handle socket state
- [x] Router integration works correctly
- [x] Error handling follows Phoenix patterns
- [x] Authorization flows work as expected

## Backward Compatibility

- [x] This change is backward compatible
- [ ] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes
<!-- If there are breaking changes, describe them here -->

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (please describe)

### Performance Notes
<!-- Describe any performance considerations -->

## Security Considerations

- [x] No security impact
- [ ] Security improvement
- [ ] Potential security impact (please describe)

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

```elixir
def create(conn, %{"item" => params}) do
  case authorize_with_transaction(
         conn,
         fn -> Repo.insert(Item.changeset(%Item{}, params)) end,
         on_unauthorized: fn _action, conn ->
           conn
           |> put_flash(:error, "Custom denied.")
           |> redirect(to: "/custom_denied")
           |> halt()
         end
       ) do
    {:ok, item} -> text(conn, "created item #{item.id}")
    {:error, %Ecto.Changeset{} = changeset} -> render(conn, :new, changeset: changeset)
    {:error, conn} -> conn
  end
end

```

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

---

<!-- Thank you for contributing to Permit.Phoenix! -->
