### PR TITLE
Add the possibility do pass options to liveview streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,9 @@ defmodule MyAppWeb.ArticleLive.Index do
 
   # Alternatively, use a callback for conditional stream usage.
   #
+  # It can return `true` for default options, or a keyword list of options
+  # passed to `Phoenix.LiveView.stream/4` (e.g. `[reset: true]`).
+  #
   # You needn't set use_stream? to false with singular actions, e.g. :show, etc.
   # - in their case, even if set to true, normal assigns will be used.
   @impl true

--- a/lib/permit_phoenix/live_view.ex
+++ b/lib/permit_phoenix/live_view.ex
@@ -913,6 +913,10 @@ defmodule Permit.Phoenix.LiveView do
 
   Defaults to `false`, which means that the resources will be assigned to `:loaded_resources`.
 
+  If it returns `true`, the resources will be streamed with default options (appended).
+  If it returns a keyword list, the resources will be streamed and the list will be passed
+  as options to `Phoenix.LiveView.stream/4` (e.g. `[reset: true]`).
+
   ## Example
 
       # Recommended: set a default use_stream? for all LiveViews
@@ -920,7 +924,7 @@ defmodule Permit.Phoenix.LiveView do
         def live_view do
           quote do
             use Permit.Phoenix.LiveView,
-              use_stream?: true,
+              use_stream?: [reset: true],
               # other options...
           end
         end
@@ -928,9 +932,10 @@ defmodule Permit.Phoenix.LiveView do
 
       # Set for a single LiveView
       @impl true
-      def use_stream?(socket), do: true
+      def use_stream?(%{assigns: %{live_action: :index}}), do: [reset: true]
+      def use_stream?(_socket), do: false
   """
-  @callback use_stream?(PhoenixTypes.socket()) :: boolean()
+  @callback use_stream?(PhoenixTypes.socket()) :: boolean() | keyword()
 
   @doc ~S"""
   Determines whether to use Phoenix Scopes for fetching the subject. Set to `false` in Phoenix <1.8.

--- a/lib/permit_phoenix/live_view/authorize_hook.ex
+++ b/lib/permit_phoenix/live_view/authorize_hook.ex
@@ -43,12 +43,12 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
          _ -> false
        end) do
       quote do
-        if is_list(unquote(value)) and unquote(socket).view.use_stream?(unquote(socket)) do
-          unquote(socket)
-          |> Phoenix.LiveView.stream(unquote(key), unquote(value))
+        evaluated_value = unquote(value)
+
+        if opts = unquote(__MODULE__).stream_options(unquote(socket), evaluated_value) do
+          Phoenix.LiveView.stream(unquote(socket), unquote(key), evaluated_value, opts)
         else
-          unquote(socket)
-          |> Phoenix.Component.assign(unquote(key), unquote(value))
+          Phoenix.Component.assign(unquote(socket), unquote(key), evaluated_value)
         end
       end
     else
@@ -58,6 +58,18 @@ defmodule Permit.Phoenix.LiveView.AuthorizeHook do
               Phoenix LiveView is not available.
               Please add a dependency {:phoenix_live_view, \"~> 0.16\"} to use LiveView integration.
               """
+      end
+    end
+  end
+
+  @doc false
+  def stream_options(socket, value) do
+    if is_list(value) do
+      case socket.view.use_stream?(socket) do
+        false -> nil
+        nil -> nil
+        true -> []
+        opts when is_list(opts) -> opts
       end
     end
   end

--- a/test/permit/ecto_live_view_test.exs
+++ b/test/permit/ecto_live_view_test.exs
@@ -93,6 +93,22 @@ defmodule Permit.EctoLiveViewTest do
       assert assigns.streams |> Map.has_key?(:loaded_resources)
     end
 
+    test "can do :index on items using a stream with options", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, "/live/items?stream=reset")
+
+      assigns = get_assigns(lv)
+
+      assert assigns.streams |> Map.has_key?(:loaded_resources)
+    end
+
+    test "can do :index on items using a stream with custom dom_id", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, "/live/items?stream=dom_id")
+
+      # The default dom_id would be something like "loaded_resources-1"
+      # But our custom one should be "custom-1"
+      assert html =~ "id=\"custom-1\""
+    end
+
     test "can do :show on owned item", %{conn: conn} do
       {:ok, lv, _html} = live(conn, "/live/items/1")
 

--- a/test/support/ecto_live_view_test/hooks_live.ex
+++ b/test/support/ecto_live_view_test/hooks_live.ex
@@ -36,6 +36,12 @@ defmodule Permit.EctoLiveViewTest.HooksLive do
     <button id="navigate_show" phx-click="navigate" phx-value-url="/live/items/1">show</button>
     <button id="navigate_edit" phx-click="navigate" phx-value-url="/live/items/1/edit">edit</button>
     <button id="delete" phx-click="delete" phx-value-id="2">delete</button>
+
+    <div :if={Map.has_key?(assigns, :streams) and Map.has_key?(assigns.streams, :loaded_resources)} id="items" phx-update="stream">
+      <div :for={{id, item} <- @streams.loaded_resources} id={id}>
+        <%= item.id %>
+      </div>
+    </div>
     """
   end
 
@@ -72,7 +78,12 @@ defmodule Permit.EctoLiveViewTest.HooksLive do
 
   @impl true
   def use_stream?(socket) do
-    socket.private.connect_info.params["stream"] == "true"
+    case socket.private.connect_info.params["stream"] do
+      "true" -> true
+      "reset" -> [reset: true]
+      "dom_id" -> [dom_id: fn item -> "custom-#{item.id}" end]
+      _ -> false
+    end
   end
 
   def run(lv, func) do


### PR DESCRIPTION
# Pull Request

## Description

This PR expands the `use_stream?/1` callback in `Permit.Phoenix.LiveView` to allow returning a keyword list of options, which are then passed directly to `Phoenix.LiveView.stream/4`

Motivation: I am using Permit in a project where there is also the Flop filter library being used. When paginating results that are being displayed in a stream I need to reset the stream (clear it) instead of just appending it. Permit was not making this possible, forcing me to first assign the results to loaded resources and then manually streaming them. But then I obviously loose the benefits of using stream in the first place. With this change users can configure how the stream should be setup. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvements
- [ ] CI/CD improvements

## Related Issues

Related to #<!-- issue number -->

## Changes Made

- **`lib/permit_phoenix/live_view/authorize_hook.ex`**: Refactored `live_view_assign` macro to delegate stream option resolution to a new `stream_options/2` helper


## Testing

### Test Environment
- [x] Elixir version: 1.18.4
- [x] OTP version: 27
- [x] Phoenix version: 1.8.1
- [x] LiveView version: 1.1.17
- [x] Database (if applicable): PostgreSQL 14

### Test Cases
- [x] All existing tests pass
- [x] New tests added for keyword list options and custom `dom_id`

### Test Commands Run
```bash
mix test
mix credo
MIX_ENV=test mix dialyzer
mix compile --warnings-as-errors
```

## Documentation

- [x] Updated README.md
- [x] Updated documentation comments (with examples for new features)
- [x] Updated controller/LiveView usage examples

## Code Quality

- [x] Code follows the existing style conventions
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] No new linting warnings introduced
- [x] No new Dialyzer warnings introduced
- [x] Follows Phoenix and LiveView conventions

## Phoenix/LiveView Specific

- [x] LiveView changes properly handle socket state
- [x] Router integration works correctly
- [x] Authorization flows work as expected

## Backward Compatibility

- [x] This change is backward compatible

## Performance Impact

- [?] No performance impact

## Security Considerations

- [?] No security impact

## Screenshots/Examples

```elixir
# Example usage of new feature
defmodule MyAppWeb.ArticleLive.Index do
  use Permit.Phoenix.LiveView,
    authorization_module: MyApp.Authorization,
    resource_module: MyApp.Article

  @impl true
  def use_stream?(%{assigns: %{live_action: :index}}), do: [reset: true, dom_id: &"item-#{&1.id}"]
  def use_stream?(_socket), do: false
end
```

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
