### PR TITLE
Add docs on how to use non-db references in resource_module

### DIFF
--- a/lib/permit_phoenix/controller.ex
+++ b/lib/permit_phoenix/controller.ex
@@ -253,6 +253,7 @@ defmodule Permit.Phoenix.Controller do
   This resource module, along with the controller action name, will be used for authorization checks before each action.
 
   If `Permit.Ecto` is used, this setting selects the Ecto schema which will be used for automatic preloading a record for authorization.
+  If you need to control access to a page which does not clearly map to a database schema, you can reference any other model, like `MyApp.Dashboard` here and then need to set skip_preload/0 so that Permit will not try to preload this non-database module. 
 
   ## Example
 


### PR DESCRIPTION
This was not immidiately obvious to me: How do I configure Permit if I have a page like a dashboard that does not clearly map to some Ecto scheme.